### PR TITLE
Add a missing stub file/correct an optional argument.

### DIFF
--- a/PythonTests/Stubs/pylint/checkers.pyi
+++ b/PythonTests/Stubs/pylint/checkers.pyi
@@ -12,7 +12,7 @@ class BaseChecker():
     def add_message(
         self,
         msgid: str,
-        line: int = None,
+        line: int = 0,
         node: Any = None,
         args: Any = None,
         confidence: Any = None,


### PR DESCRIPTION
These errors were pointed out when I updated PyRight.