### PR TITLE
Add GitHub Action that produces a docker image for Meros

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,11 @@
 end_of_line = lf
 insert_final_newline = true
 
-[*.{nim,nims,nimble}]
+[*.{nim, nims, nimble}]
+indent_style = space
+indent_size = 4
+
+
+[*.{yaml, yml}]
 indent_style = space
 indent_size = 4

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,0 +1,17 @@
+FROM nimlang/nim:1.0.4 AS builder
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    make \
+    cmake \
+    autoconf \
+    automake \
+    libtool \
+    curl
+
+COPY . ./
+RUN nimble build -y -d:nogui
+
+FROM ubuntu:devel
+COPY --from=builder ./build/Meros .
+ENTRYPOINT ["./Meros"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,26 @@
+name: build
+
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+        branches:
+            - master
+
+jobs:
+    meros:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v2
+            -   name: Docker Build
+                run: docker build -f .github/workflows/Dockerfile -t meroscrypto/meros:latest .
+            -   name: Docker Login
+                if: github.ref == 'refs/heads/master'
+                uses: azure/docker-login@v1
+                with:
+                    username: merosmaintainers
+                    password: ${{ secrets.DOCKER_PASSWORD }}
+            -   name: Docker Publish
+                if: github.ref == 'refs/heads/master'
+                run: docker push meroscrypto/meros:latest


### PR DESCRIPTION
These sets of changes provide a workflow that produces a Docker image. This Docker image is pushed
to Docker Hub for users to be able to run Meros with little to no effort via a simple `docker run` command.

### Notes

- `DOCKER_PASSWORD` must be configured in this repository
