### PR TITLE
Docker: Set frontend to noninteractive to prevent tzdata prompt

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,4 +1,6 @@
 FROM nimlang/nim:1.0.4 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive 
 RUN apt-get update && apt-get install -y \
     gcc \
     g++ \


### PR DESCRIPTION
This solely affects the Docker build environment. While installing dependencies, specifically `tzdata`, it will no longer prompt for configuration.